### PR TITLE
Mark method beforeReturn as public

### DIFF
--- a/Http/Response/Transformator/ProductTypeResolver.php
+++ b/Http/Response/Transformator/ProductTypeResolver.php
@@ -55,7 +55,7 @@ class ProductTypeResolver
      *
      * @return array
      */
-    protected function beforeReturn(array $data, string $type): array
+    public function beforeReturn(array $data, string $type): array
     {
         return [$data, $type];
     }


### PR DESCRIPTION
Only public methods can be "plugged in"